### PR TITLE
Adding a check for $.cookie so things dont blow up

### DIFF
--- a/js/track_votes.js
+++ b/js/track_votes.js
@@ -9,25 +9,27 @@
     attach: function (context) {
       var cookieName = 'polldaddyVotes' + window.location.pathname.replace("/", "-");
       var self = this;
-      var polldaddyVotes = $.cookie(cookieName) ? JSON.parse($.cookie(cookieName)) : {};
-      
-      $.each(polldaddyVotes, function(index, value) {
-        callback = 'PD_vote' + value;
-        if (window[callback]) {
-          window[callback].call(this, 1);
-        }
-      });
-      
-      $('.PDS_Poll .pds-vote-button').click(function() {
-        var buttonPrefix = "pd-vote-button";
-        var pollId = this.id.substr(buttonPrefix.length);
-        // Blindly adding polls to a cookie, but they should only be added only
-        // if they haven't been already.
-        polldaddyVotes[pollId] = pollId;
-        $.cookie(cookieName, JSON.stringify(polldaddyVotes), { expires: 1, path: '/' });
-      });
-      
-      
+
+      if ($.isFunction($.cookie)) {
+        var polldaddyVotes = $.cookie(cookieName) ? JSON.parse($.cookie(cookieName)) : {};
+
+        $.each(polldaddyVotes, function(index, value) {
+          callback = 'PD_vote' + value;
+          if (window[callback]) {
+            window[callback].call(this, 1);
+          }
+        });
+
+        $('.PDS_Poll .pds-vote-button').click(function() {
+          var buttonPrefix = "pd-vote-button";
+          var pollId = this.id.substr(buttonPrefix.length);
+          // Blindly adding polls to a cookie, but they should only be added only
+          // if they haven't been already.
+          polldaddyVotes[pollId] = pollId;
+          $.cookie(cookieName, JSON.stringify(polldaddyVotes), { expires: 1, path: '/' });
+        });
+      }
+
     }
   }
 })(jQuery);


### PR DESCRIPTION
This caused an issue with stopping the rest of javascript in the case that jquery.cookie.js could not be found. This checks for $.cookie function before continuing and potentially causing a problem.
